### PR TITLE
Set explicit ioprio where required

### DIFF
--- a/services/surfaceflinger/DispSync.cpp
+++ b/services/surfaceflinger/DispSync.cpp
@@ -21,6 +21,7 @@
 
 #include <math.h>
 
+#include <cutils/iosched_policy.h>
 #include <cutils/log.h>
 
 #include <ui/Fence.h>
@@ -292,6 +293,7 @@ DispSync::DispSync() :
         mThread(new DispSyncThread()) {
 
     mThread->run("DispSync", PRIORITY_URGENT_DISPLAY + PRIORITY_MORE_FAVORABLE);
+    android_set_rt_ioprio(mThread->getTid(), 1);
 
     reset();
     beginResync();

--- a/services/surfaceflinger/EventThread.cpp
+++ b/services/surfaceflinger/EventThread.cpp
@@ -20,6 +20,7 @@
 #include <sys/types.h>
 
 #include <cutils/compiler.h>
+#include <cutils/iosched_policy.h>
 
 #include <gui/BitTube.h>
 #include <gui/IDisplayEventConnection.h>
@@ -86,6 +87,7 @@ void EventThread::sendVsyncHintOnLocked() {
 
 void EventThread::onFirstRef() {
     run("EventThread", PRIORITY_URGENT_DISPLAY + PRIORITY_MORE_FAVORABLE);
+    android_set_rt_ioprio(getTid(), 1);
 }
 
 sp<EventThread::Connection> EventThread::createEventConnection() const {

--- a/services/surfaceflinger/SurfaceFlinger.cpp
+++ b/services/surfaceflinger/SurfaceFlinger.cpp
@@ -31,6 +31,7 @@
 #endif
 
 #include <cutils/log.h>
+#include <cutils/iosched_policy.h>
 #include <cutils/properties.h>
 
 #include <binder/IPCThreadState.h>
@@ -517,6 +518,7 @@ void SurfaceFlinger::init() {
 
     mEventControlThread = new EventControlThread(this);
     mEventControlThread->run("EventControl", PRIORITY_URGENT_DISPLAY);
+    android_set_rt_ioprio(mEventControlThread->getTid(), 1);
 
     // set a fake vsync period if there is no HWComposer
     if (mHwc->initCheck() != NO_ERROR) {


### PR DESCRIPTION
- This is just in a couple of places. We're not going to do this
  automagically anymore as the potential for badness is too high.

Change-Id: I4df869287fdf1bbb90e87deecdecf4364f7779db

Conflicts:
    services/inputflinger/InputManager.cpp
